### PR TITLE
feat: add TikTok icon to ranking label

### DIFF
--- a/src/components/tabs/SocialMedia.tsx
+++ b/src/components/tabs/SocialMedia.tsx
@@ -1448,8 +1448,8 @@ const SocialMedia = () => {
             <CardContent>
               {/* Ranking Label */}
               <div className="mb-4 text-center">
-                <span className="inline-flex items-center gap-2 bg-gradient-to-r from-[#ff0050]/10 to-[#00f2ea]/10 text-[#ff0050] text-sm font-semibold px-4 py-2 rounded-full border border-[#ff0050]/20">
-                  <Heart className="w-4 h-4 text-[#ff0050]" />
+                <span className="inline-flex items-center gap-2 bg-[#00f2ea]/10 text-[#00f2ea] text-sm font-semibold px-4 py-2 rounded-full border border-[#00f2ea]/20">
+                  <TikTokIcon className="w-4 h-4 text-[#00f2ea]" />
                   Ranked by Likes
                 </span>
               </div>


### PR DESCRIPTION
## Summary
- show TikTok logo next to "Ranked by Likes" in TikTok Videos Performance section

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Error while loading rule '@typescript-eslint/no-unused-expressions')*

------
https://chatgpt.com/codex/tasks/task_e_68a24e1af0c083288121e6c74091b2f7