### PR TITLE
Add Instagram icon to posts performance section

### DIFF
--- a/src/components/tabs/SocialMedia.tsx
+++ b/src/components/tabs/SocialMedia.tsx
@@ -787,7 +787,10 @@ const SocialMedia = () => {
 
         <Card className="shadow-soft rounded-2xl border-gray-200">
           <CardHeader className="pb-4">
-            <CardTitle className="text-lg font-semibold text-gray-800">Instagram Posts Performance</CardTitle>
+            <CardTitle className="text-lg font-semibold text-gray-800 flex items-center gap-2">
+              <Instagram className="w-5 h-5 text-pink-600" />
+              Instagram Posts Performance
+            </CardTitle>
             <CardDescription className="text-sm text-gray-600">Recent posts and their engagement metrics</CardDescription>
             
             {/* Brand Selector */}


### PR DESCRIPTION
## Summary
- add Instagram icon before `Instagram Posts Performance` title for clearer branding

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Error while loading rule '@typescript-eslint/no-unused-expressions')*

------
https://chatgpt.com/codex/tasks/task_e_68a2523d6bf48328a7c354a5e791c5ac