### PR TITLE
refine brand selectors in social media tabs

### DIFF
--- a/src/components/tabs/SocialMedia.tsx
+++ b/src/components/tabs/SocialMedia.tsx
@@ -794,19 +794,15 @@ const SocialMedia = () => {
             <CardDescription className="text-sm text-gray-600">Recent posts and their engagement metrics</CardDescription>
             
             {/* Brand Selector */}
-            <div className="mt-4 bg-warm-cream border-border shadow-soft rounded-2xl p-3">
-              <div className="flex items-center gap-3">
-                <label className="text-sm font-medium text-foreground">Brand:</label>
-                <div className="max-w-xs">
-                  <MultiSelect
-                    options={instagramUniqueBrands}
-                    selected={instagramPostsSelectedBrands}
-                    onChange={setInstagramPostsSelectedBrands}
-                    placeholder="All Brands"
-                    className="w-full text-xs bg-white/80 border-gray-200 shadow-sm rounded-lg hover:shadow-md transition-shadow duration-200"
-                  />
-                </div>
-              </div>
+            <div className="mt-4 flex flex-col gap-1 max-w-xs">
+              <label className="text-xs font-medium text-foreground">Brand</label>
+              <MultiSelect
+                options={instagramUniqueBrands}
+                selected={instagramPostsSelectedBrands}
+                onChange={setInstagramPostsSelectedBrands}
+                placeholder="All Brands"
+                className="w-full"
+              />
             </div>
           </CardHeader>
           <CardContent>
@@ -1436,19 +1432,15 @@ const SocialMedia = () => {
             <CardDescription className="text-sm text-gray-600">Recent videos and their engagement metrics</CardDescription>
             
             {/* Brand Selector */}
-            <div className="mt-4 bg-warm-cream border-border shadow-soft rounded-2xl p-3">
-              <div className="flex items-center gap-3">
-                <label className="text-sm font-medium text-foreground">Brand:</label>
-                <div className="max-w-xs">
-                  <MultiSelect
-                    options={tiktokUniqueBrands}
-                    selected={tiktokSelectedBrands}
-                    onChange={setTiktokSelectedBrands}
-                    placeholder="All Brands"
-                    className="w-full text-xs bg-white/80 border-gray-200 shadow-sm rounded-lg hover:shadow-md transition-shadow duration-200"
-                  />
-                </div>
-              </div>
+            <div className="mt-4 flex flex-col gap-1 max-w-xs">
+              <label className="text-xs font-medium text-foreground">Brand</label>
+              <MultiSelect
+                options={tiktokUniqueBrands}
+                selected={tiktokSelectedBrands}
+                onChange={setTiktokSelectedBrands}
+                placeholder="All Brands"
+                className="w-full"
+              />
             </div>
           </CardHeader>
             <CardContent>

--- a/src/components/ui/multi-select.tsx
+++ b/src/components/ui/multi-select.tsx
@@ -1,11 +1,10 @@
-import { useState, useMemo, useEffect } from "react";
-import { Check, ChevronDown, Search, X } from "lucide-react";
+import { useState, useMemo } from "react";
+import { ChevronDown, Search } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Checkbox } from "@/components/ui/checkbox";
-import { Badge } from "@/components/ui/badge";
 
 interface MultiSelectProps {
   options: string[];
@@ -27,22 +26,6 @@ export function MultiSelect({
   const [open, setOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
 
-  // Close dropdown on scroll
-  useEffect(() => {
-    const handleScroll = () => {
-      if (open) {
-        setOpen(false);
-      }
-    };
-
-    if (open) {
-      window.addEventListener('scroll', handleScroll, true);
-      return () => {
-        window.removeEventListener('scroll', handleScroll, true);
-      };
-    }
-  }, [open]);
-
   const filteredOptions = useMemo(() => {
     if (!searchTerm) return options;
     return options.filter(option => 
@@ -56,6 +39,7 @@ export function MultiSelect({
     } else {
       onChange(options);
     }
+    setOpen(true);
   };
 
   const handleToggleOption = (option: string) => {
@@ -64,10 +48,7 @@ export function MultiSelect({
     } else {
       onChange([...selected, option]);
     }
-  };
-
-  const handleRemoveSelected = (option: string) => {
-    onChange(selected.filter(item => item !== option));
+    setOpen(true);
   };
 
   const allSelected = selected.length === options.length;


### PR DESCRIPTION
## Summary
- tidy brand selectors in Instagram and TikTok performance views by removing extra wrapper styling
- keep brand dropdowns open for multiple selections via updated multi-select component

## Testing
- `npm run lint` *(fails: Error while loading rule '@typescript-eslint/no-unused-expressions')*


------
https://chatgpt.com/codex/tasks/task_e_68a26080f5088328a0cbb2885177d116