### PR TITLE
fix: keep brand selectors open and allow deselect all

### DIFF
--- a/src/components/ui/multi-select-with-totals.tsx
+++ b/src/components/ui/multi-select-with-totals.tsx
@@ -70,6 +70,7 @@ export function MultiSelectWithTotals({
     } else {
       onChange(options.map(opt => opt.brand));
     }
+    setOpen(true);
   };
 
   const handleToggleOption = (brand: string) => {
@@ -78,6 +79,7 @@ export function MultiSelectWithTotals({
     } else {
       onChange([...selected, brand]);
     }
+    setOpen(true);
   };
 
   const allSelected = selected.length === options.length;
@@ -105,7 +107,11 @@ export function MultiSelectWithTotals({
             <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
           </Button>
         </PopoverTrigger>
-        <PopoverContent className="w-full p-0 bg-white border-border rounded-xl" align="start">
+        <PopoverContent
+          className="w-full p-0 bg-white border-border rounded-xl"
+          align="start"
+          onOpenAutoFocus={(e) => e.preventDefault()}
+        >
           <div className="flex items-center border-b border-border px-3">
             <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
             <Input


### PR DESCRIPTION
## Summary
- keep brand multi-select popovers open after selecting brands
- ensure deselect all works and disable auto-focus closing

## Testing
- `npm run lint` *(fails: Error while loading rule '@typescript-eslint/no-unused-expressions')*

------
https://chatgpt.com/codex/tasks/task_e_68a281fe9c788328baa05a510e1ff8f1