### PR TITLE
Parse CSV data dynamically to render social media tab

### DIFF
--- a/src/hooks/useCSVData.ts
+++ b/src/hooks/useCSVData.ts
@@ -1,23 +1,8 @@
 import { useState, useEffect } from "react";
 import Papa from "papaparse";
 
-interface DataRow {
-  "month-year": string;
-  year: string;
-  advertiser: string;
-  "brand root": string;
-  "category level 2": string;
-  "category level 3": string;
-  "category level 8": string;
-  channel: string;
-  placement: string;
-  publisher: string;
-  impressions: number;
-  "spend (usd)": number;
-}
-
-export const useCSVData = (csvPath: string) => {
-  const [data, setData] = useState<DataRow[]>([]);
+export const useCSVData = <T = Record<string, unknown>>(csvPath: string) => {
+  const [data, setData] = useState<T[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -31,21 +16,15 @@ export const useCSVData = (csvPath: string) => {
         }
         const csvText = await response.text();
         
-        Papa.parse(csvText, {
+        Papa.parse<T>(csvText, {
           header: true,
           skipEmptyLines: true,
-          transform: (value, header) => {
-            // Convert numeric columns
-            if (header === "impressions" || header === "spend (usd)") {
-              return parseFloat(value) || 0;
-            }
-            return value;
-          },
+          dynamicTyping: true,
           complete: (results) => {
             if (results.errors.length > 0) {
               console.warn("CSV parsing warnings:", results.errors);
             }
-            setData(results.data as DataRow[]);
+            setData(results.data as T[]);
             setLoading(false);
           },
           error: (error) => {


### PR DESCRIPTION
## Summary
- generalize CSV parsing hook to support arbitrary data
- enable automatic numeric conversion for social media metrics

## Testing
- `npm run lint` *(fails: Error while loading rule '@typescript-eslint/no-unused-expressions')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a48d1e18cc8328af26808e3a2dbc31