### PR TITLE
fix: decouple investment distribution brand selectors

### DIFF
--- a/src/components/ui/multi-select-with-totals.tsx
+++ b/src/components/ui/multi-select-with-totals.tsx
@@ -57,6 +57,8 @@ export function MultiSelectWithTotals({
     } else {
       onChange(options.map(opt => opt.brand));
     }
+    // Keep popover open after selecting all/deselecting
+    setOpen(true);
   };
 
   const handleToggleOption = (brand: string) => {
@@ -67,6 +69,8 @@ export function MultiSelectWithTotals({
     } else {
       onChange([...selected, brand]);
     }
+    // Keep popover open after selecting an option
+    setOpen(true);
   };
 
   const handleOpenChange = (newOpen: boolean) => {


### PR DESCRIPTION
## Summary
- prevent MultiSelectWithTotals from closing when selecting options
- maintain separate brand filters for each chart in Investment Distribution Analysis

## Testing
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype)*

------
https://chatgpt.com/codex/tasks/task_e_68a621e7ac1c8328ba2f19b6dafd8961