### PR TITLE
Keep multi-select open after selecting items

### DIFF
--- a/src/components/ui/multi-select-with-totals.tsx
+++ b/src/components/ui/multi-select-with-totals.tsx
@@ -32,6 +32,7 @@ export function MultiSelectWithTotals({
   const [searchTerm, setSearchTerm] = useState("");
   const triggerRef = useRef<HTMLButtonElement>(null);
   const selectAllId = useId();
+  const preventCloseRef = useRef(false);
 
   // Only log when open state changes to reduce verbosity
   useEffect(() => {
@@ -58,6 +59,7 @@ export function MultiSelectWithTotals({
       onChange(options.map(opt => opt.brand));
     }
     // Keep popover open after selecting all/deselecting
+    preventCloseRef.current = true;
     setOpen(true);
   };
 
@@ -70,11 +72,16 @@ export function MultiSelectWithTotals({
       onChange([...selected, brand]);
     }
     // Keep popover open after selecting an option
+    preventCloseRef.current = true;
     setOpen(true);
   };
 
   const handleOpenChange = (newOpen: boolean) => {
     console.log(`🔄 handleOpenChange called`, { from: open, to: newOpen });
+    if (!newOpen && preventCloseRef.current) {
+      preventCloseRef.current = false;
+      return;
+    }
     setOpen(newOpen);
   };
 


### PR DESCRIPTION
## Summary
- prevent multi-select popovers from closing after choosing options
- keep dropdown open across selections in multi-select and multi-select-with-totals
- ensure outside clicks still close the simple multi-select

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any / other existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a62d9a51ec8328a0fddf6390231ed2