### PR TITLE
fix: keep social media selectors open

### DIFF
--- a/src/components/ui/multi-select.tsx
+++ b/src/components/ui/multi-select.tsx
@@ -92,18 +92,11 @@ export function MultiSelect({
             <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
           </Button>
         </PopoverTrigger>
-        <PopoverContent 
-          className="w-full p-0 bg-white border-border rounded-xl z-[9999]" 
+        <PopoverContent
+          className="w-[var(--radix-popover-trigger-width)] p-0 bg-white border-border rounded-xl"
           align="start"
           onOpenAutoFocus={(e) => e.preventDefault()}
-          onPointerDownOutside={(e) => {
-            preventCloseRef.current = false;
-            setOpen(false);
-          }}
-          onEscapeKeyDown={() => {
-            preventCloseRef.current = false;
-            setOpen(false);
-          }}
+          sideOffset={4}
         >
           <div className="flex items-center border-b border-border px-3">
             <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />


### PR DESCRIPTION
## Summary
- prevent social media company filters from closing after each selection by keeping multi-select popover open

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: Unexpected any, no-case-declarations, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68aa39d5e05c8328b4559cba5a96a5f4