### PR TITLE
Close company selectors when scrolling

### DIFF
--- a/src/components/ui/multi-select.tsx
+++ b/src/components/ui/multi-select.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useRef, useId } from "react";
+import { useState, useMemo, useRef, useId, useEffect } from "react";
 import { ChevronDown, Search } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -30,10 +30,23 @@ export function MultiSelect({
 
   const filteredOptions = useMemo(() => {
     if (!searchTerm) return options;
-    return options.filter(option => 
+    return options.filter(option =>
       option.toLowerCase().includes(searchTerm.toLowerCase())
     );
   }, [options, searchTerm]);
+
+  // Close the popover when the user scrolls the page
+  useEffect(() => {
+    if (!open) return;
+
+    const handleScroll = () => {
+      preventCloseRef.current = false;
+      setOpen(false);
+    };
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, [open]);
 
   const handleSelectAll = () => {
     if (selected.length === options.length) {


### PR DESCRIPTION
## Summary
- Ensure company dropdowns close on scroll by adding a window scroll listener to the MultiSelect component

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: found 19 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1a77b0208328856bafab31010e4c