### PR TITLE
refactor: isolate TikTok company selectors

### DIFF
--- a/src/components/tabs/SocialMedia.tsx
+++ b/src/components/tabs/SocialMedia.tsx
@@ -94,8 +94,6 @@ interface TikTokDataRow {
 
 const SocialMedia = () => {
   const [activeTab, setActiveTab] = useState("instagram");
-  const [tiktokMetricsSelectedCompanies, setTiktokMetricsSelectedCompanies] = useState<string[]>([]);
-  const [tiktokSelectedCompanies, setTiktokSelectedCompanies] = useState<string[]>([]);
   const [selectedYears, setSelectedYears] = useState<string[]>([]);
   const [selectedMonths, setSelectedMonths] = useState<string[]>([]);
   
@@ -163,15 +161,6 @@ const SocialMedia = () => {
     });
   }, [tiktokData, selectedYears, selectedMonths]);
 
-  const tiktokUniqueCompanies = useMemo(() => {
-    const companies = new Set<string>();
-    filteredTikTokData.forEach(row => {
-      if (row.company) {
-        companies.add(row.company);
-      }
-    });
-    return Array.from(companies).sort();
-  }, [filteredTikTokData]);
 
   if (instagramLoading || tiktokLoading) {
     return (
@@ -825,6 +814,19 @@ const SocialMedia = () => {
 
   const TikTokSection = () => {
     const ttData = filteredTikTokData;
+    const [tiktokMetricsSelectedCompanies, setTiktokMetricsSelectedCompanies] = useState<string[]>([]);
+    const [tiktokSelectedCompanies, setTiktokSelectedCompanies] = useState<string[]>([]);
+
+    const tiktokUniqueCompanies = useMemo(() => {
+      const companies = new Set<string>();
+      ttData.forEach(row => {
+        if (row.company) {
+          companies.add(row.company);
+        }
+      });
+      return Array.from(companies).sort();
+    }, [ttData]);
+
     const ttMetricsData =
       tiktokMetricsSelectedCompanies.length === 0
         ? ttData


### PR DESCRIPTION
## Summary
- ensure TikTok metrics and video sections use independent company selectors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 19 problems)*
- `npx eslint src/components/tabs/SocialMedia.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68ab1f60a4b083289f36c20934557e11