### PR TITLE
Clean Amazon brand names in reviews tab

### DIFF
--- a/src/components/tabs/AmazonReviews.tsx
+++ b/src/components/tabs/AmazonReviews.tsx
@@ -78,12 +78,13 @@ const AmazonReviews = () => {
     const prodRows = (productRaw as ProductRow[]).map(p => {
       const price = typeof p.Price === "number" ? p.Price : parseFloat(String(p.Price).replace(/[$,]/g, ""));
       const originalPrice = p["Original Price"] ? parseFloat(String(p["Original Price"]).replace(/[$,]/g, "")) : null;
+      const brand = p.Brand.replace(/^Visit the\s+(.*?)\s+Store$/i, "$1").trim();
       return {
         asin: p.ASIN,
         title: p["Product Title"],
         price,
         originalPrice,
-        brand: p.Brand,
+        brand,
         starRating: Number(p["Star Rating"]),
         numberOfRatings: Number(p["Number of Ratings"]),
         url: p["Product URL"],


### PR DESCRIPTION
## Summary
- clean up brand names by stripping "Visit the" and "Store" from Amazon product data

## Testing
- `npm run lint` *(fails: 17 problems (9 errors, 8 warnings))*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ab4b11c3ec8328848d565f71c209e4