### PR TITLE
Enhance Amazon reviews brand overview UI

### DIFF
--- a/src/components/tabs/AmazonReviews.tsx
+++ b/src/components/tabs/AmazonReviews.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { AlertCircle, Loader2 } from "lucide-react";
+import { AlertCircle, Loader2, Store, Tag } from "lucide-react";
 import { useCSVData } from "@/hooks/useCSVData";
 import {
   BarChart,
@@ -176,7 +176,10 @@ const AmazonReviews = () => {
     <div className="space-y-6">
       <Card>
         <CardHeader>
-          <CardTitle>Brand Overview</CardTitle>
+          <CardTitle className="flex items-center gap-2">
+            <Store className="h-5 w-5 text-primary" />
+            Brand Overview
+          </CardTitle>
           <CardDescription>General brand information</CardDescription>
         </CardHeader>
         <CardContent>
@@ -184,10 +187,13 @@ const AmazonReviews = () => {
             {brandStats.map(b => (
               <Card
                 key={b.brand}
-                className="border border-border shadow-gentle rounded-xl hover:shadow-md transition-shadow"
+                className="border border-border shadow-gentle rounded-xl bg-gradient-to-br from-background to-muted/30 hover:shadow-lg hover:-translate-y-0.5 transition-all"
               >
                 <CardHeader className="pb-2">
-                  <CardTitle className="text-lg">{b.brand}</CardTitle>
+                  <div className="flex items-center gap-2">
+                    <Tag className="h-4 w-4 text-primary" />
+                    <CardTitle className="text-lg">{b.brand}</CardTitle>
+                  </div>
                   <CardDescription>{b.productCount} products</CardDescription>
                 </CardHeader>
                 <CardContent className="pt-0">


### PR DESCRIPTION
## Summary
- add store icon to Brand Overview header
- style brand cards with gradient background and tag icon for a more polished look

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: react-refresh/only-export-components errors in existing files)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab760a43dc8328bf8a4eac9094a5a0