### PR TITLE
Add brand label to Amazon Reviews selector

### DIFF
--- a/src/components/tabs/AmazonReviews.tsx
+++ b/src/components/tabs/AmazonReviews.tsx
@@ -281,7 +281,8 @@ const AmazonReviews = () => {
             Brand Overview
           </CardTitle>
           <CardDescription>General brand information</CardDescription>
-          <div className="w-72 mt-4">
+          <div className="w-72 mt-4 flex flex-col gap-1">
+            <label className="text-xs font-medium text-foreground">Brand</label>
             <MultiSelect
               options={sortedBrandStats.map(b => b.brand)}
               selected={selectedBrands}


### PR DESCRIPTION
## Summary
- Display "Brand" label above brand selector in Amazon Reviews tab's Brand Overview section for consistent styling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 17 problems)*
- `npx eslint src/components/tabs/AmazonReviews.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ac810fa6548328945e67ac574626e8