### PR TITLE
Remove ASIN code from Amazon reviews Product Gallery

### DIFF
--- a/src/components/tabs/AmazonReviews.tsx
+++ b/src/components/tabs/AmazonReviews.tsx
@@ -510,7 +510,6 @@ const AmazonReviews = () => {
                     ⭐ {(p.avgReviewRating ?? p.starRating).toFixed(2)} ({formatNumber(p.reviewCount || p.numberOfRatings)})
                   </div>
                   <dl className="text-xs space-y-1">
-                    <div className="flex justify-between"><dt>ASIN</dt><dd>{p.asin}</dd></div>
                     <div className="flex justify-between"><dt>Currency</dt><dd>{p.currency}</dd></div>
                     <div className="flex justify-between"><dt>Country</dt><dd>{p.country}</dd></div>
                     {p.availability && (


### PR DESCRIPTION
## Summary
- remove ASIN row from Product Gallery details in Amazon reviews tab

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 17 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68acb2d43ecc8328895da8a91ebaf6f5