### PR TITLE
feat: show rating and review count in price-rating tooltip

### DIFF
--- a/src/components/tabs/AmazonReviews.tsx
+++ b/src/components/tabs/AmazonReviews.tsx
@@ -97,6 +97,12 @@ const PriceRatingTooltip = ({
         <div className="font-medium text-foreground">{product.brand}</div>
         <div className="mb-1 text-muted-foreground">{product.title}</div>
         <div className="font-semibold text-primary">{price}</div>
+        <div className="text-muted-foreground">
+          Rating: {product.starRating.toFixed(2)}
+        </div>
+        <div className="text-muted-foreground">
+          {formatNumber(product.numberOfRatings)} reviews
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- display rating and review count in the Price vs. Rating tooltip

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: 17 problems - react hooks and type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68acbe42cb708328bded5d8653a77b69