### PR TITLE
Ensure filters use Last Seen dates

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -10,6 +10,7 @@ import AmazonReviews from "./tabs/AmazonReviews";
 import { useCSVData } from "@/hooks/useCSVData";
 import { Card, CardContent } from "@/components/ui/card";
 import { Loader2, AlertCircle } from "lucide-react";
+import { parseISO, format } from "date-fns";
 
 const Dashboard = () => {
   const [activeTab, setActiveTab] = useState("executive-summary");
@@ -17,57 +18,65 @@ const Dashboard = () => {
   const { data: brandDataRaw, loading: brandLoading, error: brandError } = useCSVData("/Pathmathics_Brand_Manufacturer_plus_focus.csv");
   
   // Filter data to only include breast pump related products (focus_vs_other = 'focus')
-  // and add required month-year and year columns
-  const brandData = brandDataRaw?.filter(row => row['focus_vs_other'] === 'focus').map(row => {
-    const lastSeenDate = new Date(row['Last Seen']);
-    const year = lastSeenDate.getFullYear().toString();
-    const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-    const monthName = monthNames[lastSeenDate.getMonth()];
-    const monthYear = `${monthName} ${year}`;
-    
-    return {
-      ...row,
-      'month-year': monthYear,
-      'year': year,
-      'advertiser': row['Advertiser'],
-      'brand root': row['Brand Root'],
-      'category level 2': row['Category Level 2'],
-      'category level 3': row['Category Level 3'],
-      'category level 8': row['Category Level 8'],
-      'channel': row['Channel'],
-      'placement': row['Placement'],
-      'publisher': row['Publisher'],
-      'impressions': parseInt(row['Impressions']) || 0,
-      'spend (usd)': parseFloat(row['Spend (USD)']) || 0
-    };
-  }) || [];
+  // and add required month-year and year columns derived from Last Seen
+  const brandData =
+    brandDataRaw
+      ?.filter((row) => row["focus_vs_other"] === "focus")
+      .map((row) => {
+        const dateStr = row["Last Seen"];
+        const lastSeenDate = parseISO(String(dateStr));
+        if (isNaN(lastSeenDate.getTime())) return null;
+        const year = format(lastSeenDate, "yyyy");
+        const monthYear = format(lastSeenDate, "MMM yyyy");
+
+        return {
+          ...row,
+          "month-year": monthYear,
+          year,
+          advertiser: row["Advertiser"],
+          "brand root": row["Brand Root"],
+          "category level 2": row["Category Level 2"],
+          "category level 3": row["Category Level 3"],
+          "category level 8": row["Category Level 8"],
+          channel: row["Channel"],
+          placement: row["Placement"],
+          publisher: row["Publisher"],
+          impressions: parseInt(row["Impressions"]) || 0,
+          "spend (usd)": parseFloat(row["Spend (USD)"]) || 0,
+        };
+      })
+      .filter(Boolean) || [];
   const { data: dmeDataRaw, loading: dmeLoading, error: dmeError } = useCSVData("/Pathmatics_DME_plus_focus.csv");
   
   // Filter data to only include breast pump related products (focus_vs_other = 'focus')
-  // and add required month-year and year columns
-  const dmeData = dmeDataRaw?.filter(row => row['focus_vs_other'] === 'focus').map(row => {
-    const lastSeenDate = new Date(row['Last Seen']);
-    const year = lastSeenDate.getFullYear().toString();
-    const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-    const monthName = monthNames[lastSeenDate.getMonth()];
-    const monthYear = `${monthName} ${year}`;
-    
-    return {
-      ...row,
-      'month-year': monthYear,
-      'year': year,
-      'advertiser': row['Advertiser'],
-      'brand root': row['Brand Root'],
-      'category level 2': row['Category Level 2'],
-      'category level 3': row['Category Level 3'],
-      'category level 8': row['Category Level 8'],
-      'channel': row['Channel'],
-      'placement': row['Placement'],
-      'publisher': row['Publisher'],
-      'impressions': parseInt(row['Impressions']) || 0,
-      'spend (usd)': parseFloat(row['Spend (USD)']) || 0
-    };
-  }) || [];
+  // and add required month-year and year columns derived from Last Seen
+  const dmeData =
+    dmeDataRaw
+      ?.filter((row) => row["focus_vs_other"] === "focus")
+      .map((row) => {
+        const dateStr = row["Last Seen"];
+        const lastSeenDate = parseISO(String(dateStr));
+        if (isNaN(lastSeenDate.getTime())) return null;
+        const year = format(lastSeenDate, "yyyy");
+        const monthYear = format(lastSeenDate, "MMM yyyy");
+
+        return {
+          ...row,
+          "month-year": monthYear,
+          year,
+          advertiser: row["Advertiser"],
+          "brand root": row["Brand Root"],
+          "category level 2": row["Category Level 2"],
+          "category level 3": row["Category Level 3"],
+          "category level 8": row["Category Level 8"],
+          channel: row["Channel"],
+          placement: row["Placement"],
+          publisher: row["Publisher"],
+          impressions: parseInt(row["Impressions"]) || 0,
+          "spend (usd)": parseFloat(row["Spend (USD)"]) || 0,
+        };
+      })
+      .filter(Boolean) || [];
 
   if (brandLoading || dmeLoading) {
     return (

--- a/src/components/dashboard/FilterBar.tsx
+++ b/src/components/dashboard/FilterBar.tsx
@@ -18,16 +18,19 @@ const FilterBar = ({
   onMonthChange
 }: FilterBarProps) => {
   const { years, availableMonths } = useMemo(() => {
-    const years = [...new Set(data.map(row => row.year))].sort().reverse(); // Newest first
-    
+    const years = [...new Set(data.map(row => row.year).filter(Boolean))]
+      .sort()
+      .reverse(); // Newest first
+
     // Filter months based on selected years
-    const filteredData = selectedYears.length > 0 
-      ? data.filter(row => selectedYears.includes(row.year))
-      : data;
-    
-    const availableMonths = [...new Set(filteredData.map(row => row["month-year"]))]
+    const filteredData =
+      selectedYears.length > 0
+        ? data.filter((row) => selectedYears.includes(row.year))
+        : data;
+
+    const availableMonths = [...new Set(filteredData.map(row => row["month-year"]).filter(Boolean))]
       .sort((a, b) => new Date(b).getTime() - new Date(a).getTime()); // Newest first
-    
+
     return { years, availableMonths };
   }, [data, selectedYears]);
 


### PR DESCRIPTION
## Summary
- Derive year and month-year from `Last Seen` using `date-fns` and skip invalid rows
- Sanitize year and month lists in the filter bar to hide empty values

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 21 problems (9 errors, 12 warnings))*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b98caed44483289e13a8c173ad8020