### PR TITLE
Add top ads sections for brand and DME tabs

### DIFF
--- a/src/components/dashboard/TopAds.tsx
+++ b/src/components/dashboard/TopAds.tsx
@@ -1,0 +1,126 @@
+import { useState, useMemo } from "react";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { MultiSelect } from "@/components/ui/multi-select";
+import { Eye, BarChart3 } from "lucide-react";
+import { formatNumber } from "@/lib/utils";
+
+interface AdData {
+  advertiser: string;
+  impressions: number;
+  "spend (usd)": number;
+  Text?: string;
+  "Link To Creative"?: string;
+  "Landing Page"?: string;
+}
+
+interface TopAdsProps {
+  data: AdData[];
+}
+
+const TopAds = ({ data }: TopAdsProps) => {
+  const [selectedCompanies, setSelectedCompanies] = useState<string[]>([]);
+
+  const uniqueCompanies = useMemo(
+    () => Array.from(new Set(data.map(row => row.advertiser))).sort(),
+    [data]
+  );
+
+  const topAds = useMemo(
+    () =>
+      data
+        .filter(row => selectedCompanies.length === 0 || selectedCompanies.includes(row.advertiser))
+        .sort((a, b) => b.impressions - a.impressions)
+        .slice(0, 12),
+    [data, selectedCompanies]
+  );
+
+  return (
+    <Card className="shadow-soft rounded-2xl border-gray-200">
+      <CardHeader className="pb-4">
+        <CardTitle className="text-lg font-semibold text-gray-800">Top Ads</CardTitle>
+        <CardDescription className="text-sm text-gray-600">
+          Top 12 ads ranked by impressions
+        </CardDescription>
+        <div className="mt-4 flex flex-col gap-1 max-w-xs">
+          <label className="text-xs font-medium text-foreground">Company</label>
+          <MultiSelect
+            options={uniqueCompanies}
+            selected={selectedCompanies}
+            onChange={setSelectedCompanies}
+            placeholder="All Companies"
+            className="w-full"
+          />
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-x-4 gap-y-8">
+          {topAds.map((ad, index) => (
+            <div key={index} className="space-y-2">
+              <div className="flex items-center gap-2">
+                <span className="text-[#EA899A] text-xs font-bold px-2 py-1 rounded-full bg-[#EA899A]/10 border border-[#EA899A]/20">
+                  #{index + 1}
+                </span>
+                <span className="font-bold text-sm text-[#EA899A]">
+                  {ad.advertiser || "Unknown"}
+                </span>
+              </div>
+              <div className="bg-white border border-gray-200 rounded-xl overflow-hidden hover:shadow-lg transition-all duration-300">
+                {ad["Link To Creative"] ? (
+                  <img
+                    src={ad["Link To Creative"]}
+                    alt={ad.Text || "Ad creative"}
+                    className="w-full h-48 object-cover"
+                  />
+                ) : (
+                  <div className="w-full h-48 bg-gray-100 flex items-center justify-center">
+                    <span className="text-gray-400 text-sm">No Creative</span>
+                  </div>
+                )}
+                <div className="p-3 bg-white">
+                  <div className="mb-2">
+                    <p className="text-xs text-gray-700 line-clamp-2 leading-relaxed">
+                      {ad.Text || "No text available"}
+                    </p>
+                  </div>
+                  <div className="grid grid-cols-2 gap-2 mb-2">
+                    <div className="flex items-center gap-1 text-xs">
+                      <Eye className="w-3 h-3 text-blue-500" />
+                      <span className="text-blue-600 font-medium">
+                        {formatNumber(ad.impressions)}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-1 text-xs">
+                      <BarChart3 className="w-3 h-3 text-[#EA899A]" />
+                      <span className="text-[#EA899A] font-medium">
+                        ${formatNumber(ad["spend (usd)"])}
+                      </span>
+                    </div>
+                  </div>
+                  {ad["Landing Page"] && (
+                    <a
+                      href={ad["Landing Page"]}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1 text-xs text-[#EA899A] hover:text-[#c06776] font-medium transition-colors duration-200"
+                    >
+                      <span>Visit Landing Page</span>
+                      <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
+                        <path
+                          fillRule="evenodd"
+                          d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                          clipRule="evenodd"
+                        />
+                      </svg>
+                    </a>
+                  )}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default TopAds;

--- a/src/components/tabs/BrandManufacturer.tsx
+++ b/src/components/tabs/BrandManufacturer.tsx
@@ -4,6 +4,7 @@ import SpendImpressionsByBrand from "../dashboard/SpendImpressionsByBrand";
 import GeneralFigures from "../dashboard/GeneralFigures";
 import Timeline from "../dashboard/Timeline";
 import ConsolidatedInvestmentDistribution from "../dashboard/ConsolidatedInvestmentDistribution";
+import TopAds from "../dashboard/TopAds";
 
 interface DataRow {
   "month-year": string;
@@ -19,6 +20,9 @@ interface DataRow {
   impressions: number;
   "spend (usd)": number;
   focus_vs_other: string;
+  Text?: string;
+  "Link To Creative"?: string;
+  "Landing Page"?: string;
 }
 
 interface BrandManufacturerProps {
@@ -72,6 +76,9 @@ const BrandManufacturer = ({ data }: BrandManufacturerProps) => {
 
       {/* Investment Distribution Analysis */}
       <ConsolidatedInvestmentDistribution key="brand-manufacturer-investment" data={filteredData} tabId="brand-manufacturer" />
+
+      {/* Top Ads Section */}
+      <TopAds data={filteredData} />
     </div>
   );
 };

--- a/src/components/tabs/DMEProviders.tsx
+++ b/src/components/tabs/DMEProviders.tsx
@@ -4,6 +4,7 @@ import SpendImpressionsByBrand from "../dashboard/SpendImpressionsByBrand";
 import GeneralFigures from "../dashboard/GeneralFigures";
 import Timeline from "../dashboard/Timeline";
 import ConsolidatedInvestmentDistribution from "../dashboard/ConsolidatedInvestmentDistribution";
+import TopAds from "../dashboard/TopAds";
 
 interface DataRow {
   "month-year": string;
@@ -19,6 +20,9 @@ interface DataRow {
   impressions: number;
   "spend (usd)": number;
   focus_vs_other: string;
+  Text?: string;
+  "Link To Creative"?: string;
+  "Landing Page"?: string;
 }
 
 interface DMEProvidersProps {
@@ -72,6 +76,9 @@ const DMEProviders = ({ data }: DMEProvidersProps) => {
 
       {/* Investment Distribution Analysis */}
       <ConsolidatedInvestmentDistribution key="dme-providers-investment" data={filteredData} tabId="dme-providers" />
+
+      {/* Top Ads Section */}
+      <TopAds data={filteredData} />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- show top 12 ads with company filter on Brand Manufacturer tab
- show top 12 ads with company filter on DME Providers tab
- add reusable TopAds component

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 9 errors)
- `npx eslint src/components/tabs/BrandManufacturer.tsx src/components/tabs/DMEProviders.tsx src/components/dashboard/TopAds.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b99cdf89008328b60c1d5236d67fd3