### PR TITLE
Add executive summary comparison charts

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -15,14 +15,13 @@ import { parseISO, format } from "date-fns";
 const Dashboard = () => {
   const [activeTab, setActiveTab] = useState("executive-summary");
   
-  const { data: brandDataRaw, loading: brandLoading, error: brandError } = useCSVData("/Pathmathics_Brand_Manufacturer_plus_focus.csv");
-  
-  // Filter data to only include breast pump related products (focus_vs_other = 'focus')
-  // and add required month-year and year columns derived from Last Seen
-  const brandData =
+  const { data: brandDataRaw, loading: brandLoading, error: brandError } =
+    useCSVData("/Pathmathics_Brand_Manufacturer_plus_focus.csv");
+
+  // Parse all brand data and add derived fields
+  const brandDataAll =
     brandDataRaw
-      ?.filter((row) => row["focus_vs_other"] === "focus")
-      .map((row) => {
+      ?.map((row) => {
         const dateStr = row["Last Seen"];
         const lastSeenDate = parseISO(String(dateStr));
         if (isNaN(lastSeenDate.getTime())) return null;
@@ -43,17 +42,23 @@ const Dashboard = () => {
           publisher: row["Publisher"],
           impressions: parseInt(row["Impressions"]) || 0,
           "spend (usd)": parseFloat(row["Spend (USD)"]) || 0,
+          focus_vs_other: row["focus_vs_other"],
         };
       })
       .filter(Boolean) || [];
-  const { data: dmeDataRaw, loading: dmeLoading, error: dmeError } = useCSVData("/Pathmatics_DME_plus_focus.csv");
-  
+
   // Filter data to only include breast pump related products (focus_vs_other = 'focus')
-  // and add required month-year and year columns derived from Last Seen
-  const dmeData =
+  const brandData = brandDataAll.filter(
+    (row) => row["focus_vs_other"] === "focus"
+  );
+  const { data: dmeDataRaw, loading: dmeLoading, error: dmeError } = useCSVData(
+    "/Pathmatics_DME_plus_focus.csv"
+  );
+
+  // Parse all DME data and add derived fields
+  const dmeDataAll =
     dmeDataRaw
-      ?.filter((row) => row["focus_vs_other"] === "focus")
-      .map((row) => {
+      ?.map((row) => {
         const dateStr = row["Last Seen"];
         const lastSeenDate = parseISO(String(dateStr));
         if (isNaN(lastSeenDate.getTime())) return null;
@@ -74,9 +79,13 @@ const Dashboard = () => {
           publisher: row["Publisher"],
           impressions: parseInt(row["Impressions"]) || 0,
           "spend (usd)": parseFloat(row["Spend (USD)"]) || 0,
+          focus_vs_other: row["focus_vs_other"],
         };
       })
       .filter(Boolean) || [];
+
+  // Filter data to only include breast pump related products
+  const dmeData = dmeDataAll.filter((row) => row["focus_vs_other"] === "focus");
 
   if (brandLoading || dmeLoading) {
     return (
@@ -163,7 +172,7 @@ const Dashboard = () => {
         <Tabs value={activeTab} onValueChange={setActiveTab}>
           <div className="bg-white rounded-2xl border border-border shadow-gentle p-6">
             <TabsContent value="executive-summary" className="mt-0">
-              <ExecutiveSummary brandData={brandData} dmeData={dmeData} />
+              <ExecutiveSummary brandData={brandDataAll} />
             </TabsContent>
             
             <TabsContent value="brand-manufacturer" className="mt-0">

--- a/src/components/tabs/ExecutiveSummary.tsx
+++ b/src/components/tabs/ExecutiveSummary.tsx
@@ -1,8 +1,7 @@
 import { useMemo } from "react";
-import MetricCard from "../dashboard/MetricCard";
-import Charts from "../dashboard/Charts";
-import DataTable from "../dashboard/DataTable";
-import { DollarSign, Eye, Building, Users } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useCSVData } from "@/hooks/useCSVData";
+import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from "recharts";
 
 interface DataRow {
   "month-year": string;
@@ -17,17 +16,159 @@ interface DataRow {
   publisher: string;
   impressions: number;
   "spend (usd)": number;
+  focus_vs_other: string;
+}
+
+interface SocialRow {
+  company: string;
+  focus_vs_other: string;
 }
 
 interface ExecutiveSummaryProps {
   brandData: DataRow[];
-  dmeData: DataRow[];
 }
 
-const ExecutiveSummary = ({ brandData, dmeData }: ExecutiveSummaryProps) => {
+const COLORS = ["#EA899A", "#CBD5E1"];
+
+const ExecutiveSummary = ({ brandData }: ExecutiveSummaryProps) => {
+  const {
+    data: instagramDataRaw,
+    loading: instagramLoading,
+    error: instagramError,
+  } = useCSVData<SocialRow>("/SM_IG_Breast_Pump_Brands_plus_focus.csv");
+  const {
+    data: tiktokDataRaw,
+    loading: tiktokLoading,
+    error: tiktokError,
+  } = useCSVData<SocialRow>("/SM_TikTok_Breast_Pump_Brands_plus_focus.csv");
+
+  const spendByBrand = useMemo(() => {
+    const totals: Record<string, { focus: number; other: number }> = {};
+    brandData.forEach((row) => {
+      const brand = row["brand root"];
+      const spend = row["spend (usd)"] || 0;
+      if (!totals[brand]) totals[brand] = { focus: 0, other: 0 };
+      if (row.focus_vs_other === "focus") totals[brand].focus += spend;
+      else totals[brand].other += spend;
+    });
+    return Object.entries(totals).map(([brand, values]) => ({
+      brand,
+      focus: values.focus,
+      other: values.other,
+    }));
+  }, [brandData]);
+
+  const postsByBrand = useMemo(() => {
+    const combined = [
+      ...(instagramDataRaw || []),
+      ...(tiktokDataRaw || []),
+    ];
+    const totals: Record<string, { focus: number; other: number }> = {};
+    combined.forEach((row: SocialRow) => {
+      const brand = row.company;
+      if (!brand) return;
+      if (!totals[brand]) totals[brand] = { focus: 0, other: 0 };
+      if (row.focus_vs_other === "focus") totals[brand].focus += 1;
+      else totals[brand].other += 1;
+    });
+    return Object.entries(totals).map(([brand, values]) => ({
+      brand,
+      focus: values.focus,
+      other: values.other,
+    }));
+  }, [instagramDataRaw, tiktokDataRaw]);
+
+  if (instagramLoading || tiktokLoading) {
+    return (
+      <div className="flex items-center justify-center h-64 text-muted-foreground">
+        Loading summary...
+      </div>
+    );
+  }
+
+  if (instagramError || tiktokError) {
+    return (
+      <div className="flex items-center justify-center h-64 text-destructive">
+        Error loading social media data
+      </div>
+    );
+  }
+
   return (
-    <div className="flex items-center justify-center h-64 text-muted-foreground">
-      <p>Executive Summary coming soon...</p>
+    <div className="space-y-12">
+      <section>
+        <h2 className="text-lg font-semibold mb-4">Ad Spend Distribution</h2>
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {spendByBrand.map(({ brand, focus, other }) => (
+            <Card key={brand}>
+              <CardHeader className="pb-0 text-center">
+                <CardTitle className="text-sm font-medium">{brand}</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="h-48">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <PieChart>
+                      <Pie
+                        data={[
+                          { name: "Breast Pumps", value: focus },
+                          { name: "Other", value: other },
+                        ]}
+                        dataKey="value"
+                        nameKey="name"
+                        innerRadius="60%"
+                        outerRadius="80%"
+                        paddingAngle={2}
+                      >
+                        <Cell fill={COLORS[0]} />
+                        <Cell fill={COLORS[1]} />
+                      </Pie>
+                      <Tooltip formatter={(value) => `$${Number(value).toLocaleString()}`} />
+                      <Legend />
+                    </PieChart>
+                  </ResponsiveContainer>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-semibold mb-4">Focus in Social Media Posts</h2>
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {postsByBrand.map(({ brand, focus, other }) => (
+            <Card key={`post-${brand}`}>
+              <CardHeader className="pb-0 text-center">
+                <CardTitle className="text-sm font-medium">{brand}</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="h-48">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <PieChart>
+                      <Pie
+                        data={[
+                          { name: "Breast Pump Posts", value: focus },
+                          { name: "Other Posts", value: other },
+                        ]}
+                        dataKey="value"
+                        nameKey="name"
+                        innerRadius="60%"
+                        outerRadius="80%"
+                        paddingAngle={2}
+                      >
+                        <Cell fill={COLORS[0]} />
+                        <Cell fill={COLORS[1]} />
+                      </Pie>
+                      <Tooltip />
+                      <Legend />
+                    </PieChart>
+                  </ResponsiveContainer>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </section>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Parse and retain focus status for all brand and DME records
- Add Executive Summary tab with donut charts for ad spend and social media focus

## Testing
- `npm run lint` *(fails: 9 errors, 12 warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9a5f1a7608328b22570a7869a8281