### PR TITLE
feat: enhance executive summary with global filters

### DIFF
--- a/src/components/tabs/ExecutiveSummary.tsx
+++ b/src/components/tabs/ExecutiveSummary.tsx
@@ -1,7 +1,16 @@
-import { useMemo } from "react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useState, useMemo } from "react";
+import FilterBar from "../dashboard/FilterBar";
+import { MultiSelect } from "../ui/multi-select";
 import { useCSVData } from "@/hooks/useCSVData";
-import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from "recharts";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  ResponsiveContainer,
+  Tooltip,
+  Legend,
+} from "recharts";
 
 interface DataRow {
   "month-year": string;
@@ -31,6 +40,11 @@ interface ExecutiveSummaryProps {
 const COLORS = ["#EA899A", "#CBD5E1"];
 
 const ExecutiveSummary = ({ brandData }: ExecutiveSummaryProps) => {
+  const [selectedYears, setSelectedYears] = useState<string[]>([]);
+  const [selectedMonths, setSelectedMonths] = useState<string[]>([]);
+  const [selectedBrands, setSelectedBrands] = useState<string[]>([]);
+  const [selectedCompanies, setSelectedCompanies] = useState<string[]>([]);
+
   const {
     data: instagramDataRaw,
     loading: instagramLoading,
@@ -42,21 +56,41 @@ const ExecutiveSummary = ({ brandData }: ExecutiveSummaryProps) => {
     error: tiktokError,
   } = useCSVData<SocialRow>("/SM_TikTok_Breast_Pump_Brands_plus_focus.csv");
 
+  const filteredBrandData = useMemo(() => {
+    return brandData.filter((row) => {
+      const yearMatch =
+        selectedYears.length === 0 || selectedYears.includes(row.year);
+      const monthMatch =
+        selectedMonths.length === 0 || selectedMonths.includes(row["month-year"]);
+      return yearMatch && monthMatch;
+    });
+  }, [brandData, selectedYears, selectedMonths]);
+
+  const brandOptions = useMemo(() => {
+    return [
+      ...new Set(filteredBrandData.map((row) => row["brand root"]).filter(Boolean)),
+    ].sort();
+  }, [filteredBrandData]);
+
   const spendByBrand = useMemo(() => {
     const totals: Record<string, { focus: number; other: number }> = {};
-    brandData.forEach((row) => {
+    filteredBrandData.forEach((row) => {
       const brand = row["brand root"];
       const spend = row["spend (usd)"] || 0;
       if (!totals[brand]) totals[brand] = { focus: 0, other: 0 };
       if (row.focus_vs_other === "focus") totals[brand].focus += spend;
       else totals[brand].other += spend;
     });
-    return Object.entries(totals).map(([brand, values]) => ({
+    let results = Object.entries(totals).map(([brand, values]) => ({
       brand,
       focus: values.focus,
       other: values.other,
     }));
-  }, [brandData]);
+    if (selectedBrands.length > 0) {
+      results = results.filter((item) => selectedBrands.includes(item.brand));
+    }
+    return results;
+  }, [filteredBrandData, selectedBrands]);
 
   const postsByBrand = useMemo(() => {
     const combined = [
@@ -71,12 +105,55 @@ const ExecutiveSummary = ({ brandData }: ExecutiveSummaryProps) => {
       if (row.focus_vs_other === "focus") totals[brand].focus += 1;
       else totals[brand].other += 1;
     });
-    return Object.entries(totals).map(([brand, values]) => ({
+    let results = Object.entries(totals).map(([brand, values]) => ({
       brand,
       focus: values.focus,
       other: values.other,
     }));
-  }, [instagramDataRaw, tiktokDataRaw]);
+    if (selectedCompanies.length > 0) {
+      results = results.filter((item) =>
+        selectedCompanies.includes(item.brand)
+      );
+    }
+    return results;
+  }, [instagramDataRaw, tiktokDataRaw, selectedCompanies]);
+
+  const companyOptions = useMemo(() => {
+    return [
+      ...new Set(
+        postsByBrand.map((row) => row.brand).filter(Boolean)
+      ),
+    ].sort();
+  }, [postsByBrand]);
+
+  const createTooltip = (formatter: (v: number) => string) => {
+    return ({ active, payload, label }: any) => {
+      if (active && payload && payload.length) {
+        const total = payload.reduce(
+          (sum: number, entry: any) => sum + Number(entry.value),
+          0
+        );
+        return (
+          <div className="bg-white p-2 border rounded">
+            <p className="font-medium">{label}</p>
+            {payload.map((entry: any) => (
+              <p key={entry.name} style={{ color: entry.color }}>
+                {entry.name}: {formatter(Number(entry.value))} (
+                {((Number(entry.value) / total) * 100).toFixed(1)}%)
+              </p>
+            ))}
+            <p className="mt-1 font-medium">
+              Total: {formatter(total)}
+            </p>
+          </div>
+        );
+      }
+      return null;
+    };
+  };
+
+  const currencyTooltip = createTooltip((v) => `$${v.toLocaleString()}`);
+  const countTooltip = createTooltip((v) => v.toLocaleString());
 
   if (instagramLoading || tiktokLoading) {
     return (
@@ -95,78 +172,91 @@ const ExecutiveSummary = ({ brandData }: ExecutiveSummaryProps) => {
   }
 
   return (
-    <div className="space-y-12">
+    <div className="space-y-6">
+      <div className="bg-blue-50 border border-blue-200 rounded-lg p-3">
+        <p className="text-sm text-blue-800 font-medium">
+          Dataset covers advertising data from January 1, 2024 to July 22, 2025
+        </p>
+      </div>
+      <div className="bg-amber-50 border border-amber-200 rounded-lg p-3">
+        <p className="text-sm text-amber-800 font-medium">
+          This view shows global ad data, not limited to breast pumps
+        </p>
+      </div>
+
+      <FilterBar
+        data={brandData}
+        selectedYears={selectedYears}
+        selectedMonths={selectedMonths}
+        onYearChange={setSelectedYears}
+        onMonthChange={setSelectedMonths}
+      />
+
       <section>
         <h2 className="text-lg font-semibold mb-4">Ad Spend Distribution</h2>
-        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-          {spendByBrand.map(({ brand, focus, other }) => (
-            <Card key={brand}>
-              <CardHeader className="pb-0 text-center">
-                <CardTitle className="text-sm font-medium">{brand}</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="h-48">
-                  <ResponsiveContainer width="100%" height="100%">
-                    <PieChart>
-                      <Pie
-                        data={[
-                          { name: "Breast Pumps", value: focus },
-                          { name: "Other", value: other },
-                        ]}
-                        dataKey="value"
-                        nameKey="name"
-                        innerRadius="60%"
-                        outerRadius="80%"
-                        paddingAngle={2}
-                      >
-                        <Cell fill={COLORS[0]} />
-                        <Cell fill={COLORS[1]} />
-                      </Pie>
-                      <Tooltip formatter={(value) => `$${Number(value).toLocaleString()}`} />
-                      <Legend />
-                    </PieChart>
-                  </ResponsiveContainer>
-                </div>
-              </CardContent>
-            </Card>
-          ))}
+        <div className="max-w-sm mb-4">
+          <MultiSelect
+            options={brandOptions}
+            selected={selectedBrands}
+            onChange={setSelectedBrands}
+            placeholder="All Brands"
+          />
+        </div>
+        <div className="h-80">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={spendByBrand}>
+              <XAxis dataKey="brand" />
+              <YAxis />
+              <Tooltip content={currencyTooltip} />
+              <Legend />
+              <Bar
+                dataKey="focus"
+                stackId="a"
+                fill={COLORS[0]}
+                name="Breast Pumps"
+              />
+              <Bar
+                dataKey="other"
+                stackId="a"
+                fill={COLORS[1]}
+                name="Other"
+              />
+            </BarChart>
+          </ResponsiveContainer>
         </div>
       </section>
 
       <section>
         <h2 className="text-lg font-semibold mb-4">Focus in Social Media Posts</h2>
-        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-          {postsByBrand.map(({ brand, focus, other }) => (
-            <Card key={`post-${brand}`}>
-              <CardHeader className="pb-0 text-center">
-                <CardTitle className="text-sm font-medium">{brand}</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="h-48">
-                  <ResponsiveContainer width="100%" height="100%">
-                    <PieChart>
-                      <Pie
-                        data={[
-                          { name: "Breast Pump Posts", value: focus },
-                          { name: "Other Posts", value: other },
-                        ]}
-                        dataKey="value"
-                        nameKey="name"
-                        innerRadius="60%"
-                        outerRadius="80%"
-                        paddingAngle={2}
-                      >
-                        <Cell fill={COLORS[0]} />
-                        <Cell fill={COLORS[1]} />
-                      </Pie>
-                      <Tooltip />
-                      <Legend />
-                    </PieChart>
-                  </ResponsiveContainer>
-                </div>
-              </CardContent>
-            </Card>
-          ))}
+        <div className="max-w-sm mb-4">
+          <MultiSelect
+            options={companyOptions}
+            selected={selectedCompanies}
+            onChange={setSelectedCompanies}
+            placeholder="All Companies"
+          />
+        </div>
+        <div className="h-80">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={postsByBrand}>
+              <XAxis dataKey="brand" />
+              <YAxis />
+              <Tooltip content={countTooltip} />
+              <Legend />
+              <Bar
+                dataKey="focus"
+                stackId="a"
+                fill={COLORS[0]}
+                name="Breast Pump Posts"
+              />
+              <Bar
+                dataKey="other"
+                stackId="a"
+                fill={COLORS[1]}
+                name="Other Posts"
+              />
+            </BarChart>
+          </ResponsiveContainer>
         </div>
       </section>
     </div>


### PR DESCRIPTION
## Summary
- add dataset coverage and global data notices to Executive Summary
- add global year/month filters with brand and company selectors
- switch to stacked bar charts with percentage tooltips

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68b9a9bb0cd4832883ff349d3995add1