### PR TITLE
Rename marketing tab and refine chart styling

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import DashboardHeader from "./dashboard/DashboardHeader";
 
-import MarketingOverview from "./tabs/MarketingOverview";
+import AdOverview from "./tabs/AdOverview";
 import BrandManufacturer from "./tabs/BrandManufacturer";
 import DMEProviders from "./tabs/DMEProviders";
 import SocialMedia from "./tabs/SocialMedia";
@@ -13,7 +13,7 @@ import { Loader2, AlertCircle } from "lucide-react";
 import { parseISO, format } from "date-fns";
 
 const Dashboard = () => {
-  const [activeTab, setActiveTab] = useState("marketing-overview");
+  const [activeTab, setActiveTab] = useState("ad-overview");
   
   const { data: brandDataRaw, loading: brandLoading, error: brandError } =
     useCSVData("/Pathmathics_Brand_Manufacturer_plus_focus.csv");
@@ -132,10 +132,10 @@ const Dashboard = () => {
             <Tabs value={activeTab} onValueChange={setActiveTab} className="px-6 py-1">
               <TabsList className="grid w-full grid-cols-5 bg-transparent rounded-none border-none p-0 shadow-none">
                 <TabsTrigger
-                  value="marketing-overview"
+                  value="ad-overview"
                   className="rounded-xl data-[state=active]:bg-white data-[state=active]:shadow-soft font-bold text-black transition-all text-sm"
                 >
-                  Marketing Overview
+                  Ad Overview
                 </TabsTrigger>
                 <TabsTrigger 
                   value="brand-manufacturer" 
@@ -171,8 +171,8 @@ const Dashboard = () => {
       <div className="pt-40 container mx-auto p-6 max-w-7xl">
         <Tabs value={activeTab} onValueChange={setActiveTab}>
           <div className="bg-white rounded-2xl border border-border shadow-gentle p-6">
-            <TabsContent value="marketing-overview" className="mt-0">
-              <MarketingOverview brandData={brandDataAll} dmeData={dmeDataAll} />
+            <TabsContent value="ad-overview" className="mt-0">
+              <AdOverview brandData={brandDataAll} dmeData={dmeDataAll} />
             </TabsContent>
             
             <TabsContent value="brand-manufacturer" className="mt-0">

--- a/src/components/dashboard/SpendImpressionsByBrand.tsx
+++ b/src/components/dashboard/SpendImpressionsByBrand.tsx
@@ -171,38 +171,37 @@ const SpendImpressionsByBrand = ({ data, title = "Brand" }: SpendImpressionsByBr
       }
 
       return (
-        <div className="bg-white p-4 border border-gray-300 rounded-xl shadow-2xl max-w-xs" style={{ 
-          backgroundColor: '#ffffff', 
-          opacity: 1, 
-          zIndex: 99999 
-        }}>
+        <div
+          className="bg-white border border-gray-200 rounded-lg p-3 shadow-md text-sm max-w-xs"
+          style={{ backgroundColor: "#ffffff", opacity: 1, zIndex: 99999 }}
+        >
           <div className="space-y-2">
             <div className="flex items-center gap-2 pb-2 border-b border-gray-100">
               <div className="font-semibold text-gray-800">{label}</div>
-              <div className="text-sm text-gray-600">•</div>
+              <div className="text-xs text-gray-600">•</div>
               <div className="font-medium text-gray-700">{brand}</div>
               {brand === "Avent" && (
                 <Heart className="w-4 h-4 text-teal-600 fill-teal-600" />
               )}
             </div>
-            
+
             <div className="space-y-1">
               <div className="flex items-baseline gap-2">
-                <span className="text-sm font-medium text-gray-600">Spend:</span>
-                <span className="font-semibold text-lg" style={{ color: hoveredEntry.color }}>
+                <span className="text-xs font-medium text-gray-600">Spend:</span>
+                <span className="font-semibold" style={{ color: hoveredEntry.color }}>
                   ${formatNumber(spend)}
                 </span>
-                <span className="text-sm text-gray-500">
+                <span className="text-xs text-gray-500">
                   ({spendPercentage.toFixed(1)}%)
                 </span>
               </div>
-              
+
               <div className="flex items-baseline gap-2">
-                <span className="text-sm font-medium text-gray-600">Impressions:</span>
+                <span className="text-xs font-medium text-gray-600">Impressions:</span>
                 <span className="font-medium text-gray-700">
                   {formatNumber(impressions)}
                 </span>
-                <span className="text-sm text-gray-500">
+                <span className="text-xs text-gray-500">
                   ({impressionsPercentage.toFixed(1)}%)
                 </span>
               </div>
@@ -277,7 +276,7 @@ const SpendImpressionsByBrand = ({ data, title = "Brand" }: SpendImpressionsByBr
           </CardHeader>
           <CardContent className="overflow-visible">
             <ResponsiveContainer width="100%" height={300}>
-                <BarChart data={spendChartData} barCategoryGap="5%" maxBarSize={40}>
+                <BarChart data={spendChartData} barCategoryGap="20%" maxBarSize={20}>
                 <XAxis 
                   dataKey="year" 
                   axisLine={false} 
@@ -314,6 +313,7 @@ const SpendImpressionsByBrand = ({ data, title = "Brand" }: SpendImpressionsByBr
                       stroke={brand === "Avent" ? "hsl(173, 58%, 29%)" : "none"}
                       strokeWidth={brand === "Avent" ? 2 : 0}
                       radius={[6, 6, 0, 0]}
+                      barSize={12}
                     >
                       {brand === "Avent" && (
                         <LabelList 

--- a/src/components/dashboard/Timeline.tsx
+++ b/src/components/dashboard/Timeline.tsx
@@ -110,11 +110,10 @@ const Timeline = ({ data, title = "Brand" }: TimelineProps) => {
       const total = payload.reduce((sum: number, entry: any) => sum + (entry.value || 0), 0);
       
       return (
-        <div className="bg-white p-3 border border-gray-300 rounded-lg shadow-xl min-w-48" style={{ 
-          backgroundColor: '#ffffff', 
-          opacity: 1, 
-          zIndex: 99999 
-        }}>
+        <div
+          className="bg-white border border-gray-200 rounded-lg p-3 shadow-md text-sm min-w-48"
+          style={{ backgroundColor: "#ffffff", opacity: 1, zIndex: 99999 }}
+        >
           <div className="space-y-2">
             <div className="text-xs font-semibold text-gray-800 pb-1 border-b border-gray-100">
               {label}

--- a/src/components/tabs/AdOverview.tsx
+++ b/src/components/tabs/AdOverview.tsx
@@ -34,7 +34,7 @@ interface SocialRow {
   focus_vs_other: string;
 }
 
-interface MarketingOverviewProps {
+interface AdOverviewProps {
   brandData: DataRow[];
   dmeData: DataRow[];
 }
@@ -54,7 +54,7 @@ const formatNumber = (value: number): string => {
   return `${value}`;
 };
 
-const MarketingOverview = ({ brandData, dmeData }: MarketingOverviewProps) => {
+const AdOverview = ({ brandData, dmeData }: AdOverviewProps) => {
   const [selectedYears, setSelectedYears] = useState<string[]>([]);
   const [selectedMonths, setSelectedMonths] = useState<string[]>([]);
   const [selectedBrands, setSelectedBrands] = useState<string[]>([]);
@@ -227,15 +227,21 @@ const MarketingOverview = ({ brandData, dmeData }: MarketingOverviewProps) => {
           0
         );
         return (
-          <div className="bg-white p-2 border rounded">
-            <p className="font-medium">{label}</p>
+          <div className="bg-white border border-gray-200 rounded-lg p-3 shadow-md text-sm space-y-1">
+            <p className="font-semibold text-foreground">{label}</p>
             {payload.map((entry) => (
-              <p key={entry.name} style={{ color: entry.color }}>
-                {entry.name}: {formatter(Number(entry.value))} (
-                {((Number(entry.value) / total) * 100).toFixed(1)}%)
+              <p key={entry.name} className="flex items-center gap-2" style={{ color: entry.color }}>
+                <span
+                  className="w-2 h-2 rounded-full"
+                  style={{ backgroundColor: entry.color }}
+                />
+                <span>
+                  {entry.name}: {formatter(Number(entry.value))} (
+                  {((Number(entry.value) / total) * 100).toFixed(1)}%)
+                </span>
               </p>
             ))}
-            <p className="mt-1 font-medium">
+            <p className="pt-1 font-semibold text-foreground">
               Total: {formatter(total)}
             </p>
           </div>
@@ -304,7 +310,7 @@ const MarketingOverview = ({ brandData, dmeData }: MarketingOverviewProps) => {
         </div>
         <div className="h-80 mb-8">
           <ResponsiveContainer width="100%" height="100%">
-            <BarChart data={spendByBrand}>
+            <BarChart data={spendByBrand} barCategoryGap={32}>
               <XAxis dataKey="brand" tick={{ fill: "#4B5563", fontSize: 11 }} />
               <YAxis
                 domain={[0, maxSpend]}
@@ -319,6 +325,7 @@ const MarketingOverview = ({ brandData, dmeData }: MarketingOverviewProps) => {
                 fill={COLORS[0]}
                 name="Breast Pumps"
                 radius={[4, 4, 0, 0]}
+                barSize={12}
               />
               <Bar
                 dataKey="other"
@@ -326,6 +333,7 @@ const MarketingOverview = ({ brandData, dmeData }: MarketingOverviewProps) => {
                 fill={COLORS[1]}
                 name="Other"
                 radius={[4, 4, 0, 0]}
+                barSize={12}
               />
             </BarChart>
           </ResponsiveContainer>
@@ -344,7 +352,7 @@ const MarketingOverview = ({ brandData, dmeData }: MarketingOverviewProps) => {
         </div>
         <div className="h-80">
           <ResponsiveContainer width="100%" height="100%">
-            <BarChart data={spendByProvider}>
+            <BarChart data={spendByProvider} barCategoryGap={32}>
               <XAxis dataKey="provider" tick={{ fill: "#4B5563", fontSize: 11 }} />
               <YAxis
                 domain={[0, maxDmeSpend]}
@@ -359,6 +367,7 @@ const MarketingOverview = ({ brandData, dmeData }: MarketingOverviewProps) => {
                 fill={COLORS[0]}
                 name="Breast Pumps"
                 radius={[4, 4, 0, 0]}
+                barSize={12}
               />
               <Bar
                 dataKey="other"
@@ -366,6 +375,7 @@ const MarketingOverview = ({ brandData, dmeData }: MarketingOverviewProps) => {
                 fill={COLORS[1]}
                 name="Other"
                 radius={[4, 4, 0, 0]}
+                barSize={12}
               />
             </BarChart>
           </ResponsiveContainer>
@@ -391,7 +401,7 @@ const MarketingOverview = ({ brandData, dmeData }: MarketingOverviewProps) => {
         </h3>
         <div className="h-80 mb-8">
           <ResponsiveContainer width="100%" height="100%">
-            <BarChart data={instagramPostsByBrand}>
+            <BarChart data={instagramPostsByBrand} barCategoryGap={32}>
               <XAxis dataKey="brand" tick={{ fill: "#4B5563", fontSize: 11 }} />
               <YAxis
                 domain={[0, maxInstagramPosts]}
@@ -406,6 +416,7 @@ const MarketingOverview = ({ brandData, dmeData }: MarketingOverviewProps) => {
                 fill={COLORS[0]}
                 name="Breast Pump Posts"
                 radius={[4, 4, 0, 0]}
+                barSize={12}
               />
               <Bar
                 dataKey="other"
@@ -413,6 +424,7 @@ const MarketingOverview = ({ brandData, dmeData }: MarketingOverviewProps) => {
                 fill={COLORS[1]}
                 name="Other Posts"
                 radius={[4, 4, 0, 0]}
+                barSize={12}
               />
             </BarChart>
           </ResponsiveContainer>
@@ -423,7 +435,7 @@ const MarketingOverview = ({ brandData, dmeData }: MarketingOverviewProps) => {
         </h3>
         <div className="h-80">
           <ResponsiveContainer width="100%" height="100%">
-            <BarChart data={tiktokPostsByBrand}>
+            <BarChart data={tiktokPostsByBrand} barCategoryGap={32}>
               <XAxis dataKey="brand" tick={{ fill: "#4B5563", fontSize: 11 }} />
               <YAxis
                 domain={[0, maxTiktokPosts]}
@@ -438,6 +450,7 @@ const MarketingOverview = ({ brandData, dmeData }: MarketingOverviewProps) => {
                 fill={COLORS[0]}
                 name="Breast Pump Posts"
                 radius={[4, 4, 0, 0]}
+                barSize={12}
               />
               <Bar
                 dataKey="other"
@@ -445,6 +458,7 @@ const MarketingOverview = ({ brandData, dmeData }: MarketingOverviewProps) => {
                 fill={COLORS[1]}
                 name="Other Posts"
                 radius={[4, 4, 0, 0]}
+                barSize={12}
               />
             </BarChart>
           </ResponsiveContainer>
@@ -454,4 +468,4 @@ const MarketingOverview = ({ brandData, dmeData }: MarketingOverviewProps) => {
   );
 };
 
-export default MarketingOverview;
+export default AdOverview;


### PR DESCRIPTION
## Summary
- rename Marketing Overview tab to Ad Overview
- restyle chart tooltips for a lighter, consistent look
- slim bar widths for more uniform graphs

## Testing
- `npm run lint` *(fails: Unexpected any / other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b43368148328a5264e9b757a7226