### PR TITLE
Sort Brand Manufacturer chart by spend

### DIFF
--- a/src/components/tabs/AdOverview.tsx
+++ b/src/components/tabs/AdOverview.tsx
@@ -121,6 +121,9 @@ const AdOverview = ({ brandData, dmeData }: AdOverviewProps) => {
     if (selectedBrands.length > 0) {
       results = results.filter((item) => selectedBrands.includes(item.brand));
     }
+    results.sort(
+      (a, b) => b.focus + b.other - (a.focus + a.other)
+    );
     return results;
   }, [filteredBrandData, selectedBrands]);
 


### PR DESCRIPTION
## Summary
- sort Brand Manufacturer bars in Ad Spend Distribution by total spend

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 9 errors, 12 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68becc431e9083288141bd75bae9ba8c