### PR TITLE
Clarify breast pump data scope across tabs

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -135,7 +135,7 @@ const Dashboard = () => {
                   value="ad-overview"
                   className="rounded-xl data-[state=active]:bg-white data-[state=active]:shadow-soft font-bold text-black transition-all text-sm"
                 >
-                  Ad Overview
+                  Ads & Posts Overview
                 </TabsTrigger>
                 <TabsTrigger 
                   value="brand-manufacturer" 

--- a/src/components/tabs/AmazonReviews.tsx
+++ b/src/components/tabs/AmazonReviews.tsx
@@ -498,6 +498,12 @@ const { data: reviewRaw, loading: reviewsLoading, error: reviewsError } = useCSV
 
   return (
     <div className="space-y-6">
+      <div className="bg-amber-50 border border-amber-200 rounded-lg p-3">
+        <p className="text-sm text-amber-800 font-medium">
+          This view only includes data related to breast pump products
+        </p>
+      </div>
+
       <Card>
         <CardHeader>
           <CardTitle className="flex items-center gap-2">

--- a/src/components/tabs/BrandManufacturer.tsx
+++ b/src/components/tabs/BrandManufacturer.tsx
@@ -52,6 +52,13 @@ const BrandManufacturer = ({ data }: BrandManufacturerProps) => {
         </p>
       </div>
 
+      {/* Breast Pump Data Notice */}
+      <div className="bg-amber-50 border border-amber-200 rounded-lg p-3">
+        <p className="text-sm text-amber-800 font-medium">
+          This view only includes data related to breast pump products
+        </p>
+      </div>
+
       {/* Filter Bar */}
       <FilterBar
         data={data}

--- a/src/components/tabs/DMEProviders.tsx
+++ b/src/components/tabs/DMEProviders.tsx
@@ -52,6 +52,13 @@ const DMEProviders = ({ data }: DMEProvidersProps) => {
         </p>
       </div>
 
+      {/* Breast Pump Data Notice */}
+      <div className="bg-amber-50 border border-amber-200 rounded-lg p-3">
+        <p className="text-sm text-amber-800 font-medium">
+          This view only includes data related to breast pump products
+        </p>
+      </div>
+
       {/* Filter Bar */}
       <FilterBar
         data={data}

--- a/src/components/tabs/SocialMedia.tsx
+++ b/src/components/tabs/SocialMedia.tsx
@@ -1475,6 +1475,12 @@ const SocialMedia = () => {
         </p>
       </div>
 
+      <div className="bg-amber-50 border border-amber-200 rounded-lg py-2 px-4 mb-6 w-full">
+        <p className="text-sm text-amber-800 font-medium text-center">
+          This view only includes data related to breast pump products
+        </p>
+      </div>
+
       <div className="bg-warm-cream border-border shadow-soft rounded-2xl p-4">
         <div className="flex flex-wrap gap-4 items-start">
           <div className="flex flex-col gap-1 min-w-[200px]">


### PR DESCRIPTION
## Summary
- rename "Ad Overview" tab to "Ads & Posts Overview"
- highlight that non-overview tabs only include breast pump data

## Testing
- `npm run lint` (fails: Unexpected any, no-case-declarations, etc.)

------
https://chatgpt.com/codex/tasks/task_e_68bed03e9fe88328816f49cb877ed20d