### PR TITLE
feat: enlarge bars in spend analysis charts

### DIFF
--- a/src/components/dashboard/SpendImpressionsByBrand.tsx
+++ b/src/components/dashboard/SpendImpressionsByBrand.tsx
@@ -276,7 +276,7 @@ const SpendImpressionsByBrand = ({ data, title = "Brand" }: SpendImpressionsByBr
           </CardHeader>
           <CardContent className="overflow-visible">
             <ResponsiveContainer width="100%" height={300}>
-                <BarChart data={spendChartData} barCategoryGap="20%" maxBarSize={20}>
+                <BarChart data={spendChartData} barCategoryGap="20%" maxBarSize={40}>
                 <XAxis 
                   dataKey="year" 
                   axisLine={false} 
@@ -313,7 +313,7 @@ const SpendImpressionsByBrand = ({ data, title = "Brand" }: SpendImpressionsByBr
                       stroke={brand === "Avent" ? "hsl(173, 58%, 29%)" : "none"}
                       strokeWidth={brand === "Avent" ? 2 : 0}
                       radius={[6, 6, 0, 0]}
-                      barSize={12}
+                      barSize={24}
                     >
                       {brand === "Avent" && (
                         <LabelList 


### PR DESCRIPTION
## Summary
- widen bars in annual advertising spend analysis charts for brand and DME views

## Testing
- `npm run lint` *(fails: Unexpected any, Unexpected lexical declaration in case block, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68bedd48c60483289b6056bd90205a46