### PR TITLE
Fix donut chart tooltips

### DIFF
--- a/src/components/dashboard/ConsolidatedInvestmentDistribution.tsx
+++ b/src/components/dashboard/ConsolidatedInvestmentDistribution.tsx
@@ -44,42 +44,6 @@ const CHART_COLORS = [
   "#DBEAFE",
 ];
 
-const RADIAN = Math.PI / 180;
-interface LabelProps {
-  cx: number;
-  cy: number;
-  midAngle: number;
-  innerRadius: number;
-  outerRadius: number;
-  percent: number;
-}
-
-const renderCustomizedLabel = ({
-  cx,
-  cy,
-  midAngle,
-  innerRadius,
-  outerRadius,
-  percent,
-}: LabelProps) => {
-  const radius = innerRadius + (outerRadius - innerRadius) * 0.5;
-  const x = cx + radius * Math.cos(-midAngle * RADIAN);
-  const y = cy + radius * Math.sin(-midAngle * RADIAN);
-
-  return (
-    <text
-      x={x}
-      y={y}
-      fill="white"
-      textAnchor="middle"
-      dominantBaseline="central"
-      className="text-xs"
-    >
-      {`${(percent * 100).toFixed(0)}%`}
-    </text>
-  );
-};
-
 const StableDonutChart: React.FC<{ chartData: ChartDataItem[]; chartId: string }> = ({ chartData, chartId }) => {
   if (chartData.length === 0) {
     return (
@@ -101,8 +65,6 @@ const StableDonutChart: React.FC<{ chartData: ChartDataItem[]; chartId: string }
             outerRadius={100}
             paddingAngle={2}
             dataKey="value"
-            labelLine={false}
-            label={renderCustomizedLabel}
           >
             {chartData.map((entry, index) => (
               <Cell
@@ -112,12 +74,15 @@ const StableDonutChart: React.FC<{ chartData: ChartDataItem[]; chartId: string }
             ))}
           </Pie>
           <Tooltip
-            formatter={(value: number, name: string, entry) => [
-              `$${formatNumber(value * 1000000)} (${(
-                entry.payload.percent * 100
-              ).toFixed(1)}%)`,
-              name,
-            ]}
+            formatter={(value: number | string, name: string) => {
+              const numericValue = Number(value);
+              const total = chartData.reduce((sum, item) => sum + item.value, 0);
+              const percent = total > 0 ? (numericValue / total) * 100 : 0;
+              return [
+                `$${formatNumber(numericValue * 1000000)} (${percent.toFixed(1)}%)`,
+                name,
+              ];
+            }}
             labelFormatter={(label) => `${label}`}
           />
           <Legend


### PR DESCRIPTION
## Summary
- compute total spend percent for donut chart tooltips
- remove in-chart percentage labels from investment distribution charts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 21 problems, 9 errors, 12 warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bef365e9dc832888258ad33501e59d